### PR TITLE
Add mapbox trajec

### DIFF
--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -88,7 +88,7 @@ class TrackerLayer extends mixin(Layer) {
         "line-width": 20
       }
     }
-    map.addSource("selectedLineTraject", {type: "geojson", data: []})
+    map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})
     map.addLayer(this.trajecLineLayer, this.key)
 
     console.log(map.getSource("selectedLineTraject"))

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -84,9 +84,24 @@ class TrackerLayer extends mixin(Layer) {
       type: "line",
       source: "selectedLineTraject",
       paint: {
-        "line-color": ["get", "stroke"],
         "line-width": 2,
-        "line-gap-width": 1
+        "line-gap-width": 1,
+        "line-color": ["case",
+          ["!=", ["get", "stroke"], null], ["get", "stroke"],
+          ["match", ["get", "typeIdx"],
+            0, '#ffb400',
+            1, '#ff5400',
+            2, '#ff8080',
+            3, '#ea0000',
+            4, '#3000ff',
+            5, '#ffb400',
+            6, '#41a27b',
+            7, '#00d237',
+            8, '#b5b5b5',
+            9, '#ff8080',
+            '#ff0000'
+          ]
+        ]
       },
       filter: ['==', ["geometry-type"], 'LineString']
     }
@@ -96,9 +111,23 @@ class TrackerLayer extends mixin(Layer) {
       type: "circle",
       source: "selectedLineTraject",
       paint: {
-        'circle-color': ["get", "stroke"],
         'circle-radius': 5,
-        'circle-stroke-opacity': 1
+        'circle-color': ["case",
+          ["!=", ["get", "stroke"], null], ["get", "stroke"],
+          ["match", ["get", "typeIdx"],
+            0, '#ffb400',
+            1, '#ff5400',
+            2, '#ff8080',
+            3, '#ea0000',
+            4, '#3000ff',
+            5, '#ffb400',
+            6, '#41a27b',
+            7, '#00d237',
+            8, '#b5b5b5',
+            9, '#ff8080',
+            '#ff0000'
+          ]
+        ]
       },
       filter: ['==', ["geometry-type"], 'Point']
     }

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -86,6 +86,8 @@ class TrackerLayer extends mixin(Layer) {
     }
     map.addSource("selectedLineTraject", {type: "FeatureCollection", features: []})
     map.addLayer(this.trajecLineLayer, this.key)
+
+    this.map = map
   }
 
   /**

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -135,9 +135,6 @@ class TrackerLayer extends mixin(Layer) {
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})
     map.addLayer(this.trajecLineLayer, this.key)
     map.addLayer(this.trajectStopsLayer, this.key)
-
-    console.log(map.getSource("selectedLineTraject"))
-    console.log(map.getLayer("trajectoryLine"))
   }
 
   /**

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -91,8 +91,7 @@ class TrackerLayer extends mixin(Layer) {
     this.trajectStopsLayer = {
       id: "trajectoryStops",
       type: "circle",
-      source: "selectedLineTraject",
-      filter: ["==", ["geometry-type"], "MultiPoint"]
+      source: "selectedLineTraject"
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -82,7 +82,11 @@ class TrackerLayer extends mixin(Layer) {
     this.trajecLineLayer = {
       id: "trajectoryLine",
       type: "line",
-      source: "selectedLineTraject"
+      source: "selectedLineTraject",
+      paint: {
+        "line-color": "#00ffff",
+        "line-width": 20
+      }
     }
     map.addSource("selectedLineTraject", {type: "geojson", data: []})
     map.addLayer(this.trajecLineLayer, this.key)

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -85,7 +85,7 @@ class TrackerLayer extends mixin(Layer) {
       source: "selectedLineTraject",
       paint: {
         "line-color": ["get", "stroke"],
-        "line-width": 4,
+        "line-width": 2,
         "line-gap-width": 1
       },
       filter: ['==', ["geometry-type"], 'LineString']
@@ -97,7 +97,7 @@ class TrackerLayer extends mixin(Layer) {
       source: "selectedLineTraject",
       paint: {
         'circle-color': ["get", "stroke"],
-        'circle-radius': 4,
+        'circle-radius': 5,
         'circle-stroke-opacity': 1
       },
       filter: ['==', ["geometry-type"], 'Point']

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -92,6 +92,7 @@ class TrackerLayer extends mixin(Layer) {
       id: "trajectoryStops",
       type: "circle",
       source: "selectedLineTraject",
+      filter: ['==', '$type', 'MultiPoint']
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -252,7 +252,7 @@ class TrackerLayer extends mixin(Layer) {
     if (source) {
       source.setCoordinates(extent);
     }
-    
+    this.renderTrajectories();
   }
 
   /**
@@ -261,9 +261,7 @@ class TrackerLayer extends mixin(Layer) {
    * @private
    */
   // eslint-disable-next-line class-methods-use-this
-  onMoveEnd() {
-    this.renderTrajectories();
-  }
+  onMoveEnd() {}
 
   /**
    * Update the cursor style when hovering a vehicle.

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -91,7 +91,8 @@ class TrackerLayer extends mixin(Layer) {
     this.trajectStopsLayer = {
       id: "trajectoryStops",
       type: "circle",
-      source: "selectedLineTraject"
+      source: "selectedLineTraject",
+      filter: ["==", ["geometry-type"], "MultiPoint"]
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -86,7 +86,7 @@ class TrackerLayer extends mixin(Layer) {
       paint: {
         "line-color": ["get", "stroke"]
       },
-      filter: ['==', '$type', 'LineString']
+      filter: ['==', ["geometry-type"], 'LineString']
     }
 
     this.trajectStopsLayer = {
@@ -97,7 +97,7 @@ class TrackerLayer extends mixin(Layer) {
         'circle-radius': 6,
         'circle-color': '#B42222'
       },
-      filter: ['==', '$type', 'MultiPoint']
+      filter: ['==', ["geometry-type"], 'MultiPoint']
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -87,7 +87,7 @@ class TrackerLayer extends mixin(Layer) {
     map.addSource("selectedLineTraject", {type: "FeatureCollection", features: []})
     map.addLayer(this.trajecLineLayer, this.key)
 
-    this.map = map
+    console.log(map.getSource("selectedLineTraject"))
   }
 
   /**

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -88,6 +88,7 @@ class TrackerLayer extends mixin(Layer) {
     map.addLayer(this.trajecLineLayer, this.key)
 
     console.log(map.getSource("selectedLineTraject"))
+    console.log(map.getLayer("trajectoryLine"))
   }
 
   /**

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -92,7 +92,7 @@ class TrackerLayer extends mixin(Layer) {
       id: "trajectoryStops",
       type: "circle",
       source: "selectedLineTraject",
-      filter: ['==', '$type', 'MultiPoint']
+      filter: ["==", ["geometry-type"], "MultiPoint"]
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -84,12 +84,19 @@ class TrackerLayer extends mixin(Layer) {
       type: "line",
       source: "selectedLineTraject",
       paint: {
-        "line-color": "#00ffff",
-        "line-width": 20
+        "line-color": "#00ffff"
       }
     }
+
+    this.trajectStopsLayer = {
+      id: "trajectoryStops",
+      type: "circle",
+      source: "selectedLineTraject",
+    }
+
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})
     map.addLayer(this.trajecLineLayer, this.key)
+    map.addLayer(this.trajectStopsLayer, this.key)
 
     console.log(map.getSource("selectedLineTraject"))
     console.log(map.getLayer("trajectoryLine"))

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -154,7 +154,7 @@ class TrackerLayer extends mixin(Layer) {
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})
     map.addLayer(this.trajectLineLayer, this.key)
     map.addLayer(this.trajectLineLayerBorder, "trajectoryLine")
-    map.addLayer(this.trajectStopsLayer, this.key)
+    map.addLayer(this.trajectStopsLayer, "trajectoryLine")
     map.addLayer(this.trajectStopsLayerBorder, "trajectoryStops")
   }
 

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -84,7 +84,9 @@ class TrackerLayer extends mixin(Layer) {
       type: "line",
       source: "selectedLineTraject",
       paint: {
-        "line-color": ["get", "stroke"]
+        "line-color": ["get", "stroke"],\
+        "line-width": 4,
+        "line-gap-width": 1
       },
       filter: ['==', ["geometry-type"], 'LineString']
     }
@@ -94,8 +96,9 @@ class TrackerLayer extends mixin(Layer) {
       type: "circle",
       source: "selectedLineTraject",
       paint: {
-        'circle-radius': 6,
-        'circle-color': '#B42222'
+        'circle-color': ["get", "stroke"],
+        'circle-radius': 4,
+        'circle-stroke-opacity': 1
       },
       filter: ['==', ["geometry-type"], 'Point']
     }

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -92,7 +92,7 @@ class TrackerLayer extends mixin(Layer) {
       id: "trajectoryStops",
       type: "circle",
       source: "selectedLineTraject",
-      filter: ["!=", ["geometry-type"], "MultiPoint"]
+      filter: ['==', '$type', 'MultiPoint']
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -79,13 +79,12 @@ class TrackerLayer extends mixin(Layer) {
 
     this.listeners = [this.on('change:visible', this.onVisibilityChange)];
 
-    this.trajecLineLayer = {
+    this.trajectLineLayer = {
       id: "trajectoryLine",
       type: "line",
       source: "selectedLineTraject",
       paint: {
-        "line-width": 2,
-        "line-gap-width": 1,
+        "line-width": 4,
         "line-color": ["case",
           ["!=", ["get", "stroke"], null], ["get", "stroke"],
           ["match", ["get", "typeIdx"],
@@ -106,12 +105,22 @@ class TrackerLayer extends mixin(Layer) {
       filter: ['==', ["geometry-type"], 'LineString']
     }
 
+    this.trajectLineLayerBorder = {
+      id: "trajectoryLineBorder",
+      type: "line",
+      source: "selectedLineTraject",
+      paint: {
+        "line-width": 6,
+      },
+      filter: ['==', ["geometry-type"], 'LineString']
+    }
+
     this.trajectStopsLayer = {
       id: "trajectoryStops",
       type: "circle",
       source: "selectedLineTraject",
       paint: {
-        'circle-radius': 5,
+        'circle-radius': 4,
         'circle-color': ["case",
           ["!=", ["get", "stroke"], null], ["get", "stroke"],
           ["match", ["get", "typeIdx"],
@@ -132,9 +141,21 @@ class TrackerLayer extends mixin(Layer) {
       filter: ['==', ["geometry-type"], 'Point']
     }
 
+    this.trajectStopsLayerBorder = {
+      id: "trajectoryStopsBorder",
+      type: "circle",
+      source: "selectedLineTraject",
+      paint: {
+        'circle-radius': 5,
+      },
+      filter: ['==', ["geometry-type"], 'Point']
+    }
+
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})
-    map.addLayer(this.trajecLineLayer, this.key)
+    map.addLayer(this.trajectLineLayer, this.key)
+    map.addLayer(this.trajectLineLayerBorder, "trajectoryLine")
     map.addLayer(this.trajectStopsLayer, this.key)
+    map.addLayer(this.trajectStopsLayerBorder, "trajectoryStops")
   }
 
   /**
@@ -154,8 +175,14 @@ class TrackerLayer extends mixin(Layer) {
       if (this.map.getLayer("trajectoryLine")) {
         this.map.removeLayer("trajectoryLine")
       }
-      if (this.map.getLayer("trajectStopsLayer")) {
-        this.map.removeLayer("trajectStopsLayer")
+      if (this.map.getLayer("trajectoryLineBorder")) {
+        this.map.removeLayer("trajectoryLineBorder")
+      }
+      if (this.map.getLayer("trajectoryStops")) {
+        this.map.removeLayer("trajectoryStops")
+      }
+      if (this.map.getLayer("trajectoryStopsBorder")) {
+        this.map.removeLayer("trajectoryStopsBorder")
       }
       if (this.map.getSource("selectedLineTraject")) {
         this.map.removeSource("selectedLineTraject")

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -252,7 +252,7 @@ class TrackerLayer extends mixin(Layer) {
     if (source) {
       source.setCoordinates(extent);
     }
-    this.renderTrajectories(true);
+    
   }
 
   /**
@@ -261,7 +261,9 @@ class TrackerLayer extends mixin(Layer) {
    * @private
    */
   // eslint-disable-next-line class-methods-use-this
-  onMoveEnd() {}
+  onMoveEnd() {
+    this.renderTrajectories();
+  }
 
   /**
    * Update the cursor style when hovering a vehicle.

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -252,7 +252,7 @@ class TrackerLayer extends mixin(Layer) {
     if (source) {
       source.setCoordinates(extent);
     }
-    this.renderTrajectories();
+    this.renderTrajectories(true);
   }
 
   /**

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -84,7 +84,7 @@ class TrackerLayer extends mixin(Layer) {
       type: "line",
       source: "selectedLineTraject"
     }
-    map.addSource("selectedLineTraject", {type: "FeatureCollection", features: []})
+    map.addSource("selectedLineTraject", {type: "geojson", data: []})
     map.addLayer(this.trajecLineLayer, this.key)
 
     console.log(map.getSource("selectedLineTraject"))

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -84,7 +84,7 @@ class TrackerLayer extends mixin(Layer) {
       type: "line",
       source: "selectedLineTraject",
       paint: {
-        "line-color": ["get", "stroke"],\
+        "line-color": ["get", "stroke"],
         "line-width": 4,
         "line-gap-width": 1
       },

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -102,6 +102,12 @@ class TrackerLayer extends mixin(Layer) {
       if (this.map.getSource(this.key)) {
         this.map.removeSource(this.key);
       }
+      if (this.map.getLayer("trajectoryLine")) {
+        this.map.removeLayer("trajectoryLine")
+      }
+      if (this.map.getSource("selectedLineTraject")) {
+        this.map.removeSource("selectedLineTraject")
+      }
     }
     super.terminate();
   }

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -78,6 +78,14 @@ class TrackerLayer extends mixin(Layer) {
     map.addLayer(this.layer, this.beforeId);
 
     this.listeners = [this.on('change:visible', this.onVisibilityChange)];
+
+    this.trajecLineLayer = {
+      id: "trajectoryLine",
+      type: "line",
+      source: "selectedLineTraject"
+    }
+    map.addSource("selectedLineTraject", {type: "FeatureCollection", features: []})
+    map.addLayer(this.trajecLineLayer, this.key)
   }
 
   /**

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -92,6 +92,10 @@ class TrackerLayer extends mixin(Layer) {
       id: "trajectoryStops",
       type: "circle",
       source: "selectedLineTraject",
+      paint: {
+        'circle-radius': 6,
+        'circle-color': '#B42222'
+      },
       filter: ['==', '$type', 'MultiPoint']
     }
 

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -84,7 +84,7 @@ class TrackerLayer extends mixin(Layer) {
       type: "line",
       source: "selectedLineTraject",
       paint: {
-        "line-color": "#00ffff"
+        "line-color": ["get", "stroke"]
       }
     }
 
@@ -118,6 +118,9 @@ class TrackerLayer extends mixin(Layer) {
       }
       if (this.map.getLayer("trajectoryLine")) {
         this.map.removeLayer("trajectoryLine")
+      }
+      if (this.map.getLayer("trajectStopsLayer")) {
+        this.map.removeLayer("trajectStopsLayer")
       }
       if (this.map.getSource("selectedLineTraject")) {
         this.map.removeSource("selectedLineTraject")

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -92,7 +92,7 @@ class TrackerLayer extends mixin(Layer) {
       id: "trajectoryStops",
       type: "circle",
       source: "selectedLineTraject",
-      filter: ["==", ["geometry-type"], "MultiPoint"]
+      filter: ["!=", ["geometry-type"], "MultiPoint"]
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -85,7 +85,8 @@ class TrackerLayer extends mixin(Layer) {
       source: "selectedLineTraject",
       paint: {
         "line-color": ["get", "stroke"]
-      }
+      },
+      filter: ['==', '$type', 'LineString']
     }
 
     this.trajectStopsLayer = {

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -97,7 +97,7 @@ class TrackerLayer extends mixin(Layer) {
         'circle-radius': 6,
         'circle-color': '#B42222'
       },
-      filter: ['==', ["geometry-type"], 'MultiPoint']
+      filter: ['==', ["geometry-type"], 'Point']
     }
 
     map.addSource("selectedLineTraject", {"type": "geojson", "data": {"type": "FeatureCollection", "features": []}})

--- a/src/mapbox/layers/TrackerLayer.js
+++ b/src/mapbox/layers/TrackerLayer.js
@@ -275,6 +275,15 @@ class TrackerLayer extends mixin(Layer) {
       ? 'pointer'
       : 'auto';
   }
+
+  /**
+   * Create a copy of the TrackerLayer.
+   * @param {Object} newOptions Options to override
+   * @return {TrackerLayer} A TrackerLayer
+   */
+   clone(newOptions) {
+    return new TrackerLayer({ ...this.options, ...newOptions });
+  }
 }
 
 export default TrackerLayer;

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -93,13 +93,14 @@ class TralisLayer extends mixin(TrackerLayer) {
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
         //delete fullTrajectory["properties"]
+        const props = fullTrajectory.features[0].properties
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
             newCoords.push(toLonLat(coord))
           }
           element.coordinates = newCoords
-          fullTrajectory.features.push(element)
+          fullTrajectory.features.push({type: "Feature", geometry: element, properties: props})
         });
         fullTrajectory.features.shift()
 

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -92,7 +92,7 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
-        delete fullTrajectory["properties"]
+        //delete fullTrajectory["properties"]
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,6 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
         console.log(this.map.getSource("selectedLineTraject"))
+        console.log(this.map.getLayer("trajectoryLine"))
       })
   }
 

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push([coord[0] / 100000, coord[1] / 100000 - 16])
+            newCoords.push(Object.values(this.map.unproject([coord[0] / 100000, coord[1] / 100000], 0)))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push(Object.values(this.map.project([coord[0] / 100000, coord[1] / 100000], 0)))
+            newCoords.push(Object.values([coord[0] / 100000, coord[1] / 100000]))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -92,6 +92,7 @@ class TralisLayer extends mixin(TrackerLayer) {
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
+        console.log(this.map.getSource("selectedLineTraject"))
       })
   }
 

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -99,7 +99,10 @@ class TralisLayer extends mixin(TrackerLayer) {
             newCoords.push(toLonLat(coord))
           }
           element.coordinates = newCoords
+          fullTrajectory.features.push(element)
         });
+        fullTrajectory.features.shift()
+
         console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
         // console.log(this.map.getSource("selectedLineTraject"))

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push([coord[0] / 100000 - 16, coord[1] / 100000])
+            newCoords.push([coord[0] / 100000, coord[1] / 100000 - 16])
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -100,10 +100,7 @@ class TralisLayer extends mixin(TrackerLayer) {
             newCoords.push(toLonLat(coord))
           }
           element.coordinates = newCoords
-          fullTrajectory.features.push({type: "Feature", geometry: element, properties: props})
         });
-        fullTrajectory.features.shift()
-
         console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
         // console.log(this.map.getSource("selectedLineTraject"))

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -91,6 +91,7 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
+        delete fullTrajectory["properties"]
         console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
         console.log(this.map.getSource("selectedLineTraject"))

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -94,10 +94,10 @@ class TralisLayer extends mixin(TrackerLayer) {
         delete fullTrajectory["properties"]
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           for (const coord of element.coordinates) {
-            console.log(coord)
+            coord = [coord[0] / 100000, coord[1] / 100000]
           }
         });
-        // console.log(JSON.stringify(fullTrajectory))
+        console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
         // console.log(this.map.getSource("selectedLineTraject"))
         // console.log(this.map.getLayer("trajectoryLine"))

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -1,5 +1,6 @@
 import TrackerLayer from './TrackerLayer';
 import mixin from '../../common/mixins/TralisLayerMixin';
+import { toLonLat } from 'ol/proj';
 
 /**
  * Responsible for loading and display data from a Tralis service.
@@ -95,7 +96,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push(Object.values([coord[0] / 100000, coord[1] / 100000]))
+            newCoords.push(toLonLat(coord))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push([coord[0] / 100000, coord[1] / 100000])
+            newCoords.push([coord[0] / 100000 - 16, coord[1] / 100000])
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -91,69 +91,71 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
-        const vectorSource = this.vectorLayer.getSource();
-        vectorSource.clear();
 
-        if (
-          !fullTrajectory ||
-          !fullTrajectory.features ||
-          !fullTrajectory.features.length
-        ) {
-          return;
-        }
+        console.log(fullTrajectory)
+        // const vectorSource = this.vectorLayer.getSource();
+        // vectorSource.clear();
 
-        let lineColor = '#ffffff'; // white
+        // if (
+        //   !fullTrajectory ||
+        //   !fullTrajectory.features ||
+        //   !fullTrajectory.features.length
+        // ) {
+        //   return;
+        // }
 
-        if (this.useDelayStyle) {
-          lineColor = '#a0a0a0'; // grey
-        } else {
-          const props = fullTrajectory.features[0].properties;
-          const { type } = props;
-          let { stroke } = props;
+        // let lineColor = '#ffffff'; // white
 
-          if (stroke && stroke[0] !== '#') {
-            stroke = `#${stroke}`;
-          }
+        // if (this.useDelayStyle) {
+        //   lineColor = '#a0a0a0'; // grey
+        // } else {
+        //   const props = fullTrajectory.features[0].properties;
+        //   const { type } = props;
+        //   let { stroke } = props;
 
-          lineColor = stroke || getBgColor(type);
+        //   if (stroke && stroke[0] !== '#') {
+        //     stroke = `#${stroke}`;
+        //   }
 
-          // Don't allow white lines, use red instead.
-          lineColor = /#ffffff/i.test(lineColor) ? '#ff0000' : lineColor;
-        }
-        const style = [
-          new Style({
-            zIndex: 2,
-            image: new Circle({
-              radius: 5,
-              fill: new Fill({
-                color: '#000000',
-              }),
-            }),
-            stroke: new Stroke({
-              color: '#000000',
-              width: 6,
-            }),
-          }),
-          new Style({
-            zIndex: 3,
-            image: new Circle({
-              radius: 4,
-              fill: new Fill({
-                color: lineColor,
-              }),
-            }),
-            stroke: new Stroke({
-              color: lineColor,
-              width: 4,
-            }),
-          }),
-        ];
-        this.vectorLayer.setStyle(style);
-        const features = format.readFeatures(fullTrajectory);
-        features.forEach((feature) => {
-          feature.setStyle(style);
-        });
-        this.vectorLayer.getSource().addFeatures(features);
+        //   lineColor = stroke || getBgColor(type);
+
+        //   // Don't allow white lines, use red instead.
+        //   lineColor = /#ffffff/i.test(lineColor) ? '#ff0000' : lineColor;
+        // }
+        // const style = [
+        //   new Style({
+        //     zIndex: 2,
+        //     image: new Circle({
+        //       radius: 5,
+        //       fill: new Fill({
+        //         color: '#000000',
+        //       }),
+        //     }),
+        //     stroke: new Stroke({
+        //       color: '#000000',
+        //       width: 6,
+        //     }),
+        //   }),
+        //   new Style({
+        //     zIndex: 3,
+        //     image: new Circle({
+        //       radius: 4,
+        //       fill: new Fill({
+        //         color: lineColor,
+        //       }),
+        //     }),
+        //     stroke: new Stroke({
+        //       color: lineColor,
+        //       width: 4,
+        //     }),
+        //   }),
+        // ];
+        // this.vectorLayer.setStyle(style);
+        // const features = format.readFeatures(fullTrajectory);
+        // features.forEach((feature) => {
+        //   feature.setStyle(style);
+        // });
+        // this.vectorLayer.getSource().addFeatures(features);
       });
   }
 

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push([coord[0] / 100000, coord[1] / 100000])
+            newCoords.push(this.map.unproject([coord[0] / 100000, coord[1] / 100000]))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push(this.map.unproject([coord[0] / 100000, coord[1] / 100000]))
+            newCoords.push(Object.values(this.map.unproject([coord[0] / 100000, coord[1] / 100000])))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -1,6 +1,7 @@
 import TrackerLayer from './TrackerLayer';
 import mixin from '../../common/mixins/TralisLayerMixin';
 import { toLonLat } from 'ol/proj';
+import { getTypeIndex } from '../../common/trackerConfig';
 
 /**
  * Responsible for loading and display data from a Tralis service.
@@ -93,7 +94,12 @@ class TralisLayer extends mixin(TrackerLayer) {
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
         // delete fullTrajectory["properties"]
-        const props = fullTrajectory.features[0].properties
+        const stroke = fullTrajectory.features[0].properties.stroke
+        if (stroke && stroke[0] !== '#') {
+          fullTrajectory.features[0].properties.stroke = `#${stroke}`;
+        }
+        const type = fullTrajectory.features[0].properties.type
+        fullTrajectory.features[0].properties.typeIdx = getTypeIndex(type)
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push(Object.values(this.map.unproject([coord[0] / 100000, coord[1] / 100000])))
+            newCoords.push(Object.values(this.map.project([coord[0] / 100000, coord[1] / 100000])))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -93,7 +93,6 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
-        // delete fullTrajectory["properties"]
         const stroke = fullTrajectory.features[0].properties.stroke
         if (stroke && stroke[0] !== '#') {
           fullTrajectory.features[0].properties.stroke = `#${stroke}`;
@@ -107,7 +106,6 @@ class TralisLayer extends mixin(TrackerLayer) {
           }
           element.coordinates = newCoords
         });
-        // console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
       })
   }

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -93,9 +93,11 @@ class TralisLayer extends mixin(TrackerLayer) {
       .then((fullTrajectory) => {
         delete fullTrajectory["properties"]
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
+          const newCoords = []
           for (const coord of element.coordinates) {
-            coord = [coord[0] / 100000, coord[1] / 100000]
+            newCoords.push([coord[0] / 100000, coord[1] / 100000])
           }
+          element.coordinates = newCoords
         });
         console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push(Object.values(this.map.project([coord[0] / 100000, coord[1] / 100000])))
+            newCoords.push([coord[0] / 100000, coord[1] / 100000])
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -107,10 +107,8 @@ class TralisLayer extends mixin(TrackerLayer) {
           }
           element.coordinates = newCoords
         });
-        console.log(JSON.stringify(fullTrajectory))
+        // console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
-        // console.log(this.map.getSource("selectedLineTraject"))
-        // console.log(this.map.getLayer("trajectoryLine"))
       })
   }
 

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -95,7 +95,7 @@ class TralisLayer extends mixin(TrackerLayer) {
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []
           for (const coord of element.coordinates) {
-            newCoords.push(Object.values(this.map.unproject([coord[0] / 100000, coord[1] / 100000], 0)))
+            newCoords.push(Object.values(this.map.project([coord[0] / 100000, coord[1] / 100000], 0)))
           }
           element.coordinates = newCoords
         });

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -92,7 +92,7 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
-        //delete fullTrajectory["properties"]
+        delete fullTrajectory["properties"]
         const props = fullTrajectory.features[0].properties
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -92,7 +92,7 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
-        delete fullTrajectory["properties"]
+        // delete fullTrajectory["properties"]
         const props = fullTrajectory.features[0].properties
         fullTrajectory.features[0].geometry.geometries.forEach(element => {
           const newCoords = []

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -92,10 +92,15 @@ class TralisLayer extends mixin(TrackerLayer) {
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
         delete fullTrajectory["properties"]
-        console.log(JSON.stringify(fullTrajectory))
+        fullTrajectory.features[0].geometry.geometries.forEach(element => {
+          for (const coord of element.coordinates) {
+            console.log(coord)
+          }
+        });
+        // console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
-        console.log(this.map.getSource("selectedLineTraject"))
-        console.log(this.map.getLayer("trajectoryLine"))
+        // console.log(this.map.getSource("selectedLineTraject"))
+        // console.log(this.map.getLayer("trajectoryLine"))
       })
   }
 

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -60,14 +60,14 @@ class TralisLayer extends mixin(TrackerLayer) {
       this.setBbox();
     }
 
-    if (
-      this.visible &&
-      this.isUpdateBboxOnMoveEnd &&
-      this.isClickActive &&
-      this.selectedVehicleId
-    ) {
-      this.highlightTrajectory(this.selectedVehicleId);
-    }
+    // if (
+    //   this.visible &&
+    //   this.isUpdateBboxOnMoveEnd &&
+    //   this.isClickActive &&
+    //   this.selectedVehicleId
+    // ) {
+    //   this.highlightTrajectory(this.selectedVehicleId);
+    // }
   }
 
   /**

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -91,6 +91,7 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
+        console.log(JSON.stringify(fullTrajectory))
         this.map.getSource("selectedLineTraject").setData(fullTrajectory)
         console.log(this.map.getSource("selectedLineTraject"))
       })

--- a/src/mapbox/layers/TralisLayer.js
+++ b/src/mapbox/layers/TralisLayer.js
@@ -91,72 +91,8 @@ class TralisLayer extends mixin(TrackerLayer) {
     this.api
       .getFullTrajectory(id, this.mode, this.generalizationLevel)
       .then((fullTrajectory) => {
-
-        console.log(fullTrajectory)
-        // const vectorSource = this.vectorLayer.getSource();
-        // vectorSource.clear();
-
-        // if (
-        //   !fullTrajectory ||
-        //   !fullTrajectory.features ||
-        //   !fullTrajectory.features.length
-        // ) {
-        //   return;
-        // }
-
-        // let lineColor = '#ffffff'; // white
-
-        // if (this.useDelayStyle) {
-        //   lineColor = '#a0a0a0'; // grey
-        // } else {
-        //   const props = fullTrajectory.features[0].properties;
-        //   const { type } = props;
-        //   let { stroke } = props;
-
-        //   if (stroke && stroke[0] !== '#') {
-        //     stroke = `#${stroke}`;
-        //   }
-
-        //   lineColor = stroke || getBgColor(type);
-
-        //   // Don't allow white lines, use red instead.
-        //   lineColor = /#ffffff/i.test(lineColor) ? '#ff0000' : lineColor;
-        // }
-        // const style = [
-        //   new Style({
-        //     zIndex: 2,
-        //     image: new Circle({
-        //       radius: 5,
-        //       fill: new Fill({
-        //         color: '#000000',
-        //       }),
-        //     }),
-        //     stroke: new Stroke({
-        //       color: '#000000',
-        //       width: 6,
-        //     }),
-        //   }),
-        //   new Style({
-        //     zIndex: 3,
-        //     image: new Circle({
-        //       radius: 4,
-        //       fill: new Fill({
-        //         color: lineColor,
-        //       }),
-        //     }),
-        //     stroke: new Stroke({
-        //       color: lineColor,
-        //       width: 4,
-        //     }),
-        //   }),
-        // ];
-        // this.vectorLayer.setStyle(style);
-        // const features = format.readFeatures(fullTrajectory);
-        // features.forEach((feature) => {
-        //   feature.setStyle(style);
-        // });
-        // this.vectorLayer.getSource().addFeatures(features);
-      });
+        this.map.getSource("selectedLineTraject").setData(fullTrajectory)
+      })
   }
 
   /**


### PR DESCRIPTION
Implement highlight trajectories for mapbox as in OpenLayers.
Can be tested with smartcity by locally changing the brach of the yarn plugin from master to this (ass-mapbox-trajec) with:
`yarn add Scenwise/mobility-toolbox-js#add-mapbox-trajec`